### PR TITLE
Fix $setCellStateForNextGeneration with 8 living neighbors

### DIFF
--- a/main.wat
+++ b/main.wat
@@ -14,11 +14,13 @@
     $dead
     $dead
     $dead
+    $dead
     ;; for cells that are currently alive
     $dead
     $dead
     $alive
     $alive
+    $dead
     $dead
     $dead
     $dead
@@ -221,7 +223,7 @@
       (call_indirect (result i32)
         (i32.or
           (i32.mul
-            (i32.const 8)
+            (i32.const 9)
             (call $isCellAlive
               (get_local $x)
               (get_local $y)


### PR DESCRIPTION
Your lookup table was designed to handle 0 to 7 living neighbors. For dead cells with 8 living neighbors the result is correct because it overflows into the section of the table that's meant for living cells. For a living cell with 8 living neighbors you would get an index of 16 which is out of bounds.